### PR TITLE
chore(core-security): apply dependency updates convention plugin

### DIFF
--- a/core-security/build.gradle.kts
+++ b/core-security/build.gradle.kts
@@ -7,6 +7,8 @@ plugins {
     // Quality plugins (expose detekt/ktlint tasks for aggregates)
     id("githubusers.quality.detekt")
     id("githubusers.quality.ktlint")
+    // Dependency updates (ben-manes via convention plugin)
+    id("githubusers.dependency.update")
     // Optional publishing hooks (keeps parity with other modules)
     id("githubusers.android.publishing")
     id("githubusers.android.library.publishing")


### PR DESCRIPTION
Apply dependency updates convention plugin to core-security so it exposes :dependencyUpdates / :updateDependencies like other modules.

Change
- core-security: apply `githubusers.dependency.update`

Impact
- Enables consistent dependency update checks across all core/feature modules
- No runtime or API changes

Verification
- `:core-security:tasks` lists `dependencyUpdates` and `updateDependencies`
- Root aggregators (:lintAll, :detektAll, :ktlintCheckAll, :testAll) remain green on main from prior PR
