### PR TITLE
ci(gradle): fix dependency update job for Gradle 9 (no CC for versions plugin)

### DIFF
--- a/.github/workflows/security-and-maintenance.yml
+++ b/.github/workflows/security-and-maintenance.yml
@@ -51,8 +51,8 @@ jobs:
     - name: Make gradlew executable
       run: chmod +x ./gradlew
     
-    - name: Check for dependency updates
-      run: ./gradlew dependencyUpdatesAll
+    - name: Check for dependency updates (no CC)
+      run: ./gradlew dependencyUpdatesAll --no-configuration-cache --stacktrace
     
     - name: Upload dependency update report
       uses: actions/upload-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -174,7 +174,7 @@ tasks.register("ktlintCheckAll") {
     }
 }
 
-// Aggregate dependency updates across modules that apply the versions plugin
+// Aggregate dependency updates across modules (composite-friendly)
 // Note: the ben-manes versions task is not configuration-cache safe on Gradle 9.
 // Prefer running this in isolation with configuration cache disabled.
 tasks.register("dependencyUpdatesAll") {
@@ -192,6 +192,12 @@ tasks.register("dependencyUpdatesAll") {
                 dependsOn(linkedTask)
             }
         }
+}
+
+// This aggregate depends on included builds and the ben-manes versions plugin, which is not CC-safe on Gradle 9.
+// Explicitly mark it as incompatible so Gradle won't attempt to cache the configuration for this task.
+tasks.named("dependencyUpdatesAll") {
+    notCompatibleWithConfigurationCache("Aggregate dependencyUpdates across included builds; versions plugin not CC-safe on Gradle 9")
 }
 
 // Aggregate unit tests across modules (composite-friendly)


### PR DESCRIPTION
This PR stabilizes the *Dependency Update Check* job on Gradle 9 by:

- Running `dependencyUpdatesAll` with `--no-configuration-cache --stacktrace` in the Security & Maintenance workflow
- Marking the aggregate `dependencyUpdatesAll` task as configuration-cache incompatible in the root build

Rationale
- The ben-manes versions task is not CC-safe on Gradle 9. Disabling CC for this path avoids runtime failures and preserves CC for the rest of the build.

Scope
- CI-only behavior change for dependency update step
- No impact to normal build/test tasks

Follow-ups (optional)
- Pin a Gradle 9–compatible ben-manes version via the version catalog
- Consider a per-module matrix for dependency updates to improve isolation

Validated locally via Gradle MCP: `detektAll`, `ktlintCheckAll`, and `assembleDebugApp` passed.